### PR TITLE
Reset change count when project window is opened

### DIFF
--- a/inform/Project/IFProjectController.m
+++ b/inform/Project/IFProjectController.m
@@ -201,6 +201,13 @@ static CGFloat const      minDividerWidth     = 75.0f;
 }
 
 - (void)windowDidBecomeMain:(NSNotification *)notification {
+
+    // When a document is first opened, its change count is
+    // immediatedly incremented, although it has no changes.
+    // We reset that here.
+    if (betweenWindowLoadedAndBecomingMain)
+        [[self document] updateChangeCount:NSChangeCleared];
+
     betweenWindowLoadedAndBecomingMain = NO;
 
     [toolbarManager redrawToolbar];


### PR DESCRIPTION
When a document is opened, its change count is immediately incremented, which is obviously incorrect, because it just opened and has no changes. This is annoying, because trying to close the project or quitting Inform right after it has opened will throw up an "Are you sure?" dialog.

What happens is that the delegate method `[IFSkeinPage didResizeSplitView]` is called when the window is opened, which calls `[IFSkeinPage setTestingTabHelpShownSetting:]`, which calls `[IFCompilerSettings setTestingTabHelpShown:]`, which calls `[IFCompilerSettings settingsHaveChanged]`, which issues a `IFSettingNotification` that `[IFProjectController updateSettings]`responds to, marking the document as edited.

I'm not sure which of these if any should be considered a bug and should be changed, or how, but fortunately we can just set the document as unedited instead in the `windowDidBecomeMain` method, the first time it is called after loading.

[See bug I7-1845.](https://inform7.atlassian.net/browse/I7-1845?jql=text%20~%20%22ide%22)