### PR TITLE
IFSettings: Fix some methods that weren't being properly overridden

### DIFF
--- a/inform/Settings/IFSetting.h
+++ b/inform/Settings/IFSetting.h
@@ -8,6 +8,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // Notification strings
 extern NSNotificationName const IFSettingHasChangedNotification;
 extern NSString* const IFSettingCreateBlorb;
@@ -24,7 +26,7 @@ extern NSString* const IFSettingCreateBlorb;
 @interface IFSetting : NSObject
 
 /// Initialises the setting object, and loads the given nib
-- (instancetype) initWithNibName: (NSString*) nibName NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithNibName: (nullable NSNibName) nibName NS_DESIGNATED_INITIALIZER;
 
 // Setting up the view
 /// The settings view
@@ -37,7 +39,7 @@ extern NSString* const IFSettingCreateBlorb;
 /// The compiler settings object that this setting will use
 @property (atomic, weak) IFCompilerSettings *compilerSettings;
 /// Retrieves the settings dictionary for this object
-- (NSMutableDictionary*) dictionary;
+- (nullable NSMutableDictionary*) dictionary;
 
 // Communicating with the IFCompilerSettings object
 /// (OVERRIDE) Sets values in the compiler settings (or the dictionary) from the current UI choices
@@ -49,13 +51,15 @@ extern NSString* const IFSettingCreateBlorb;
 
 // Notifying the controller about things
 /// Action called when the user changes a setting option
-- (IBAction) settingsHaveChanged: (id) sender;
+- (IBAction) settingsHaveChanged: (nullable id) sender;
 
 // Saving settings
 /// Retrieves the Plist dictionary for this setting
-@property (atomic, readonly, copy) NSDictionary *plistEntries;
+@property (atomic, readonly, copy, nullable) NSDictionary *plistEntries;
 /// Updates the values for this setting from a Plist dictionary
 - (void) updateSettings: (IFCompilerSettings*) settings
 	   withPlistEntries: (NSDictionary*) entries;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/inform/Settings/Specifics/IFAdvancedSettings.swift
+++ b/inform/Settings/Specifics/IFAdvancedSettings.swift
@@ -14,7 +14,7 @@ class IFAdvancedSettings: IFSetting {
         self.init(nibName:"AdvancedSettings")
     }
 
-    func title() -> String! {
+    override var title: String! {
         return IFUtility.localizedString("Extensions Settings")
     }
 

--- a/inform/Settings/Specifics/IFAdvancedSettings.swift
+++ b/inform/Settings/Specifics/IFAdvancedSettings.swift
@@ -14,23 +14,23 @@ class IFAdvancedSettings: IFSetting {
         self.init(nibName:"AdvancedSettings")
     }
 
-    override var title: String! {
+    override var title: String {
         return IFUtility.localizedString("Extensions Settings")
     }
 
     override func updateFromCompilerSettings() {
-        let settings:IFCompilerSettings! = self.compilerSettings
+        let settings = self.compilerSettings!
 
         allowLegacyExtensionDirectory.state = settings.allowLegacyExtensionDirectory ? NSControl.StateValue.on : NSControl.StateValue.off
     }
 
     override func setSettings() {
-        let settings:IFCompilerSettings! = self.compilerSettings
+        let settings = self.compilerSettings
 
-        settings.allowLegacyExtensionDirectory = allowLegacyExtensionDirectory.state==NSControl.StateValue.on
+        settings?.allowLegacyExtensionDirectory = allowLegacyExtensionDirectory.state==NSControl.StateValue.on
     }
 
-    override func enable(forCompiler compiler:String!) -> Bool {
+    override func enable(forCompiler compiler:String) -> Bool {
         return true
     }
 }

--- a/inform/Settings/Specifics/IFBasicInformSettings.swift
+++ b/inform/Settings/Specifics/IFBasicInformSettings.swift
@@ -14,23 +14,23 @@ class IFBasicInformSettings : IFSetting {
         self.init(nibName:"BasicInformSettings")
     }
 
-    override var title: String! {
+    override var title: String {
         return IFUtility.localizedString("Basic Inform")
     }
 
     override func updateFromCompilerSettings() {
-        let settings:IFCompilerSettings! = self.compilerSettings
+        let settings = self.compilerSettings!
 
         basicInform.state = settings.basicInform ? NSControl.StateValue.on : NSControl.StateValue.off
     }
 
     override func setSettings() {
-        let settings:IFCompilerSettings! = self.compilerSettings
+        let settings = self.compilerSettings
 
-        settings.basicInform = basicInform.state == NSControl.StateValue.on
+        settings?.basicInform = basicInform.state == NSControl.StateValue.on
     }
 
-    override func enable(forCompiler compiler: String!) -> Bool {
+    override func enable(forCompiler compiler: String) -> Bool {
         // These settings only apply to Natural Inform
         return compiler == IFCompilerNaturalInform
     }

--- a/inform/Settings/Specifics/IFBasicInformSettings.swift
+++ b/inform/Settings/Specifics/IFBasicInformSettings.swift
@@ -14,7 +14,7 @@ class IFBasicInformSettings : IFSetting {
         self.init(nibName:"BasicInformSettings")
     }
 
-    func title() -> String! {
+    override var title: String! {
         return IFUtility.localizedString("Basic Inform")
     }
 
@@ -30,7 +30,7 @@ class IFBasicInformSettings : IFSetting {
         settings.basicInform = basicInform.state == NSControl.StateValue.on
     }
 
-    func enableForCompiler(compiler:String!) -> Bool {
+    override func enable(forCompiler compiler: String!) -> Bool {
         // These settings only apply to Natural Inform
         return compiler == IFCompilerNaturalInform
     }

--- a/inform/Settings/Specifics/IFRandomSettings.swift
+++ b/inform/Settings/Specifics/IFRandomSettings.swift
@@ -14,7 +14,7 @@ class IFRandomSettings : IFSetting {
         self.init(nibName:"RandomSettings")
     }
 
-    func title() -> String! {
+    override var title: String! {
         return IFUtility.localizedString("Randomness Settings")
     }
 
@@ -30,7 +30,7 @@ class IFRandomSettings : IFSetting {
         settings.nobbleRng = makePredictable.state == NSControl.StateValue.on
     }
 
-    func enableForCompiler(compiler:String!) -> Bool {
+    override func enable(forCompiler compiler: String!) -> Bool {
         // These settings only apply to Natural Inform
         return compiler == IFCompilerNaturalInform
     }

--- a/inform/Settings/Specifics/IFRandomSettings.swift
+++ b/inform/Settings/Specifics/IFRandomSettings.swift
@@ -14,23 +14,23 @@ class IFRandomSettings : IFSetting {
         self.init(nibName:"RandomSettings")
     }
 
-    override var title: String! {
+    override var title: String {
         return IFUtility.localizedString("Randomness Settings")
     }
 
     override func updateFromCompilerSettings() {
-        let settings:IFCompilerSettings! = self.compilerSettings
+        let settings = self.compilerSettings!
 
         makePredictable.state = settings.nobbleRng ? NSControl.StateValue.on : NSControl.StateValue.off
     }
 
     override func setSettings() {
-        let settings:IFCompilerSettings! = self.compilerSettings
+        let settings = self.compilerSettings
 
-        settings.nobbleRng = makePredictable.state == NSControl.StateValue.on
+        settings?.nobbleRng = makePredictable.state == NSControl.StateValue.on
     }
 
-    override func enable(forCompiler compiler: String!) -> Bool {
+    override func enable(forCompiler compiler: String) -> Bool {
         // These settings only apply to Natural Inform
         return compiler == IFCompilerNaturalInform
     }


### PR DESCRIPTION
…in Swift.

This should fix the title for `IFAdvancedSettings`, `IFBasicInformSettings`, and `IFRandomSettings`.