### PR TITLE
Fix skein scrolling to top on every edit (#45)

### DIFF
--- a/inform/Project/Skein/IFSkeinView.m
+++ b/inform/Project/Skein/IFSkeinView.m
@@ -226,9 +226,6 @@ static NSDictionary* itemTextAttributes;
     [layoutTree setSelectedItem: selectedItem];
 	[layoutTree layoutSkein];
 
-    // Resize the view to the size of the new layout
-    [self resizeView];
-
     // Tell the report to update itself based on the new skein
     [skeinViewChildren updateReportDetails];
 


### PR DESCRIPTION
Fixes #45.

`-layoutSkeinWithAnimation:` in `IFSkeinView.m` called `resizeView` twice. The first call ran before the report layout was accounted for, temporarily shrinking the view and forcing the enclosing scroll view to jump to the top on every edit. The second `resizeView` call (after `updateLayoutWithReportDetails:`) already sizes the view to the final layout, so the first call is redundant as well as harmful.

This removes the first call, preserving the scroll position when editing the skein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)